### PR TITLE
add check for PFUI tanks

### DIFF
--- a/TankPlates.lua
+++ b/TankPlates.lua
@@ -17,6 +17,10 @@ end
 
 local player_guid = nil
 local tracked_guids = {}
+local pfuiEnabled = false
+if 1 == IsAddOnLoaded("pfUI") then
+  pfuiEnabled = true
+end
 
 local cc_spells = {
   "Polymorph",

--- a/TankPlates.lua
+++ b/TankPlates.lua
@@ -85,6 +85,13 @@ local function UpdateTarget(guid,targetArg)
   end
 end
 
+local function UnitIsPfuiTank(enemy_target_name)
+	if not pfuiEnabled then return false end
+	if not enemy_target_name then return false end
+	if pfUI.uf.raid.tankrole[enemy_target_name] then return true end
+	return false
+end
+
 local function InitPlate(plate)
   if plate.initialized then return end
   local guid = plate:GetName(1)

--- a/TankPlates.lua
+++ b/TankPlates.lua
@@ -172,17 +172,17 @@ local function InitPlate(plate)
         -- For instance if we choose (0,0,1,1) blue, the shagu reads this as friendly player and may color based on class.
         -- Due to this yellow (neutral) has been chosen for now.
         this:SetStatusBarColor(1, 1, 0, 0.6)
-      elseif (unit.casting and (unit.casting_at == player_guid or unit.previous_target == player_guid)) then
-        -- casting on someone but was attacking you
+      elseif (unit.casting and (unit.casting_at == player_guid or unit.previous_target == player_guid or UnitIsPfuiTank(unit.previous_target_name))) then
+        -- casting on someone but was attacking you or another tank (toggled on via pfui)
         this:SetStatusBarColor(0, 1, 0, 1) -- green
-      elseif unit.current_target == player_guid then
-        -- attacking you
+      elseif unit.current_target == player_guid or UnitIsPfuiTank(unit.current_target_name) then
+        -- attacking you or another tank (toggled on via pfui)
         this:SetStatusBarColor(0, 1, 0, 1) -- green
-      elseif not unit.casting and (not unit.current_target and unit.previous_target == player_guid) then
-        -- fleeing but was attacking you
+      elseif not unit.casting and (not unit.current_target and (unit.previous_target == player_guid or UnitIsPfuiTank(unit.previous_target_name))) then
+        -- fleeing but was attacking you or another tank (toggled on via pfui)
         this:SetStatusBarColor(0, 1, 0, 1) -- green
       else
-        -- not attacking you
+        -- not attacking you or another tank
         this:SetStatusBarColor(1, 0, 0, 1) -- red
       end
     else

--- a/TankPlates.lua
+++ b/TankPlates.lua
@@ -78,8 +78,10 @@ local function UpdateTarget(guid,targetArg)
     -- only update previous target if there is a current one
     if tracked_guids[guid].current_target then
       tracked_guids[guid].previous_target = tracked_guids[guid].current_target
+      tracked_guids[guid].previous_target_name = tracked_guids[guid].current_target_name
     end
     tracked_guids[guid].current_target = targeting
+    tracked_guids[guid].current_target_name = UnitName(targeting)
   end
 end
 
@@ -208,7 +210,9 @@ local function Update()
             unit_name_color = { plate.namefontstring:GetTextColor() },
             healthbar_color = { plate:GetChildren():GetStatusBarColor() },
             current_target = nil,
+            current_target_name = nil,
             previous_target = nil,
+            previous_target_name = nil,
             tick = 0,
             cc = false,
             casting = false,


### PR DESCRIPTION
The check is useful if the player is using PFUI but decided not to use PFUI nameplates.
These changes will try to check if PFUI is loaded, and attemtp to check if the enemy target is a tank in order to colour the plate correctly.

I have added "current_target_name" and "previous_target_name" to the stored values for each unit instead of converting the GUID at a later point. Hopefully this has a lower impact on performance.